### PR TITLE
Fixed windows-specific output path separator and removed Exports sublevel

### DIFF
--- a/mod_data_extractor/Program.cs
+++ b/mod_data_extractor/Program.cs
@@ -101,7 +101,7 @@ namespace UtocDumper
                     // Load all of the objects from the uasset file
                     var exports = provider.LoadAllObjects(entry.Path);
                     // Concat output file path
-                    string filePath = outputPath + @"\Exports\" + entry.PathWithoutExtension + ".json";
+                    string filePath = Path.Combine(outputPath, entry.PathWithoutExtension + ".json");
                     // Create missing directories if not exists
                     string? directoryName = new FileInfo(filePath).DirectoryName;
                     if (directoryName == null)


### PR DESCRIPTION
Replaces `outputPath + @"\Exports\" + entry.PathWithoutExtension + ".json"` with `Path.Combine(outputPath, entry.PathWithoutExtension + ".json")` to respect the platform's path separator and remove the unnecessary extra subdirectory. If somebody needs the Exports folder, it can be added to the --output option to achieve the same effect.